### PR TITLE
Added AirportResponse model as a response model for "/references/airports/{airportCode}" request. 

### DIFF
--- a/LH_public_API_swagger_2_0.json
+++ b/LH_public_API_swagger_2_0.json
@@ -22,6 +22,145 @@
       "tokenUrl": "https://api.lufthansa.com/v1/oauth/token"
     }
   },
+  "definitions": {
+    "Coordinate": {
+      "type": "object",
+      "description": "Container for coordinates.",
+      "properties": {
+        "Latitude": {
+          "type": "number",
+          "format": "float",
+          "description": "Decimal latitude. Range: -90 (South Pole) to +90 (North Pole), e.g. “51.540”."
+        },
+        "Longitude": {
+          "type": "number",
+          "format": "float",
+          "description": "Decimal longitude. Range: -180 (West of Prime Meridian) to +180 (East of Prime Meridian)."
+        }
+      }
+    },
+    "Name": {
+      "type": "object",
+      "description": "2-letter ISO 639-1 language code for the corresponding item.",
+      "properties": {
+        "@LanguageCode": {
+          "type": "string"
+        },
+        "$": {
+          "type": "string"
+        }
+      }
+    },
+    "Link": {
+      "type": "object",
+      "properties": {
+        "@Href": {
+          "type": "string",
+          "description": "Link to actual a resource."
+        },
+        "@Rel": {
+          "type": "string",
+          "description": "Specifying kind of link such as ‘self’ (link that returned this response), ‘alternate’ (link that points to another resource) or ‘related’ (link that points to related resource)."
+        }
+      }
+    },
+    "Airport": {
+      "type": "object",
+      "description": "Array of all available airports or one airport matching the request.",
+      "properties": {
+        "AirportCode": {
+          "type": "string",
+          "description": "3-letter IATA airport code, e.g. “TXL”."
+        },
+        "Position": {
+          "type": "object",
+          "description": "Physical location of an airport. This data section is optional and therefore not always present.",
+          "properties": {
+            "Coordinate": {
+              "$ref": "#/definitions/Coordinate"
+            }
+          }
+        },
+        "CityCode": {
+          "type": "string",
+          "description": "3-letter IATA city code, e.g. “BER”."
+        },
+        "CountryCode": {
+          "type": "string",
+          "description": "2-letter ISO 3166-1 country code, e.g. “DE”."
+        },
+        "LocationType": {
+          "type": "string",
+          "description": " “Airport”, “RailwayStation” or “BusStation”."
+        },
+        "Names": {
+          "type": "object",
+          "description": "Container for airport names.",
+          "properties": {
+            "Name" : {
+              "type": "array",
+              "description": "Array: language specific full name of airport.",
+              "items": {
+                "$ref": "#/definitions/Name"
+              }
+            }
+          }
+        },
+        "UtcOffset": {
+          "type": "number",
+          "format": "float",
+          "description": "Hour offset of airport to UTC time zone"
+        },
+        "TimeZoneId": {
+          "type": "string",
+          "description": "Time zone name airport is in"
+        }
+      }
+    },
+    "AirportResource": {
+      "type": "object",
+      "description": "Root element of airport response.",
+      "properties": {
+        "Airports": {
+          "type": "object",
+          "description": "Container for airport elements.",
+          "properties": {
+            "Airport" : {
+              "$ref": "#/definitions/Airport"
+            }
+          }
+        },
+        "Meta": {
+          "type": "object",
+          "description": "Container for meta links.",
+          "properties": {
+            "@Version": {
+              "type": "string"
+            },
+            "Link": {
+              "type": "array",
+              "description": "Array: links to resource itself and other related resources.",
+              "items": {
+                "$ref": "#/definitions/Link"
+              }
+            },
+            "TotalCount": {
+              "type": "integer",
+              "format": "int32"
+            }
+          }
+        }
+      }
+    },
+    "AirportResponse": {
+      "type": "object",
+      "properties": {
+        "AirportResource": {
+          "$ref": "#/definitions/AirportResource"
+        }
+      }
+    }
+  },
   "schemes": [
     "https"
   ],
@@ -242,7 +381,7 @@
           "200": {
             "description": "",
             "schema": {
-              "type": "object"
+              "$ref": "#/definitions/AirportResponse"
             },
             "examples": {}
           }


### PR DESCRIPTION
Also added several other models:
Coordinate
Name
Link
Airport
AirportResource

It is very useful to have response models for requests in swagger file since it allows to generate API more efficiently(with all underlying response types).

There are also couple of questions with current server API implementation for airport reference data requests:
From [https://developer.lufthansa.com/docs/read/api_details/reference_data/Airports](url) :

{airportCode} | Optionally return only this airport. | 3-letter IATA airport code, e.g. “TXL”.
-- | -- | --
{languageCode} | Optionally return the airport name in only this language. | 2-letter ISO 639-1 language code, e.g. “EN”.
{recordLimit} | Optionally sets the number of records returned. Defaults to 20, maximum is 100. | integer, e, g, 44
{recordOffset} | Optionally sets the number of records skipped when sorting response records alphabetically. Defaults to 0. | integer, e.g. 123
LHoperated | If set to true, only locations with flights operated by Lufthansa will be returned. | String 'true' / ' false'

So from this specification it is possible to return list of airports. But from swagger file it is required to specify {airportCode} - should it be changed?

Considering question above there is one inconsistency in Lufthansa API server behavior:

1. For  references/airports/{airportCode} request with {airportCode} equal to "TXL" we have the following response:
`{
    "AirportResource": {
        "Airports": {
            "Airport": {
                "AirportCode": "TXL",
                "Position": {
                    "Coordinate": {
                        "Latitude": 52.56027778,
                        "Longitude": 13.29555556
                    }
                },
                "CityCode": "BER",
                "CountryCode": "DE",
                "LocationType": "Airport",
                "Names": {
                    "Name": [{
                        "@LanguageCode": "xx",
                        "$": "Berlin - Tegel"
                    }, {
                        "@LanguageCode": "de",
                        "$": "Berlin - Tegel"
                    }, {
                        "@LanguageCode": "pt",
                        "$": "Berlim - Tegel"
                    }, {
                        "@LanguageCode": "en",
                        "$": "Berlin - Tegel"
                    }, {
                        "@LanguageCode": "it",
                        "$": "Berlino - Tegel"
                    }, {
                        "@LanguageCode": "fr",
                        "$": "Berlin - Tegel"
                    }, {
                        "@LanguageCode": "nl",
                        "$": "Berlijn (Tegel)"
                    }, {
                        "@LanguageCode": "es",
                        "$": "Berlin - Tegel"
                    }]
                },
                "UtcOffset": 2,
                "TimeZoneId": "Europe\/Berlin"
            }
        },
        "Meta": {
            "@Version": "1.0.0",
            "Link": [{
                "@Href": "https:\/\/api.lufthansa.com\/v1\/references\/airports\/TXL?limit=20&LHoperated=0&offset=0",
                "@Rel": "self"
            }, {
                "@Href": "https:\/\/api.lufthansa.com\/v1\/references\/cities\/BER",
                "@Rel": "related"
            }, {
                "@Href": "https:\/\/api.lufthansa.com\/v1\/references\/countries\/DE",
                "@Rel": "related"
            }, {
                "@Href": "http:\/\/travelguide.lufthansa.com\/de\/de\/berlin\/TXL",
                "@Rel": "alternate"
            }, {
                "@Href": "http:\/\/travelguide.lufthansa.com\/de\/en\/berlin\/TXL",
                "@Rel": "alternate"
            }, {
                "@Href": "http:\/\/travelguide.lufthansa.com\/de\/cn\/berlin\/TXL",
                "@Rel": "alternate"
            }, {
                "@Href": "http:\/\/travelguide.lufthansa.com\/de\/es\/berlin\/TXL",
                "@Rel": "alternate"
            }, {
                "@Href": "http:\/\/travelguide.lufthansa.com\/de\/fr\/berlin\/TXL",
                "@Rel": "alternate"
            }, {
                "@Href": "http:\/\/travelguide.lufthansa.com\/de\/it\/berlino\/TXL",
                "@Rel": "alternate"
            }, {
                "@Href": "http:\/\/travelguide.lufthansa.com\/de\/pt\/berlim\/TXL",
                "@Rel": "alternate"
            }]
        }
    }
}`

So "Airport" is an object, which contains information about "TXL" airport.

2. For  references/airports/{airportCode} request with empty {airportCode} and limit equal "2" we have the following response:
`{
    "AirportResource": {
        "Airports": {
            "Airport": [{
                "AirportCode": "AAL",
                "Position": {
                    "Coordinate": {
                        "Latitude": 57.09305556,
                        "Longitude": 9.85
                    }
                },
                "CityCode": "AAL",
                "CountryCode": "DK",
                "LocationType": "Airport",
                "Names": {
                    "Name": [{
                        "@LanguageCode": "xx",
                        "$": "Aalborg"
                    }, {
                        "@LanguageCode": "de",
                        "$": "Aalborg"
                    }, {
                        "@LanguageCode": "ru",
                        "$": "Ольборг"
                    }, {
                        "@LanguageCode": "pt",
                        "$": "Aalborg"
                    }, {
                        "@LanguageCode": "jp",
                        "$": "オールボア"
                    }, {
                        "@LanguageCode": "kr",
                        "$": "올보르그"
                    }, {
                        "@LanguageCode": "en",
                        "$": "Aalborg"
                    }, {
                        "@LanguageCode": "it",
                        "$": "Aalborg"
                    }, {
                        "@LanguageCode": "fr",
                        "$": "Aalborg"
                    }, {
                        "@LanguageCode": "es",
                        "$": "Aalborg"
                    }, {
                        "@LanguageCode": "ka",
                        "$": "奧爾堡"
                    }, {
                        "@LanguageCode": "pl",
                        "$": "Aalbork"
                    }, {
                        "@LanguageCode": "mi",
                        "$": "奥尔堡"
                    }]
                },
                "UtcOffset": 2,
                "TimeZoneId": "Europe\/Copenhagen"
            }, {
                "AirportCode": "AAR",
                "Position": {
                    "Coordinate": {
                        "Latitude": 56.30388889,
                        "Longitude": 10.62
                    }
                },
                "CityCode": "AAR",
                "CountryCode": "DK",
                "LocationType": "Airport",
                "Names": {
                    "Name": [{
                        "@LanguageCode": "xx",
                        "$": "Aarhus"
                    }, {
                        "@LanguageCode": "en",
                        "$": "Aarhus"
                    }, {
                        "@LanguageCode": "de",
                        "$": "Aarhus"
                    }, {
                        "@LanguageCode": "it",
                        "$": "Aarhus"
                    }, {
                        "@LanguageCode": "fr",
                        "$": "Aarhus"
                    }, {
                        "@LanguageCode": "es",
                        "$": "Aarhus"
                    }]
                },
                "UtcOffset": 2,
                "TimeZoneId": "Europe\/Copenhagen"
            }]
        },
        "Meta": {
            "@Version": "1.0.0",
            "Link": [{
                "@Href": "https:\/\/api.lufthansa.com\/v1\/references\/airports\/?limit=2&LHoperated=0&offset=0",
                "@Rel": "self"
            }, {
                "@Href": "https:\/\/api.lufthansa.com\/v1\/references\/airports\/?limit=2&LHoperated=0&offset=2",
                "@Rel": "next"
            }, {
                "@Href": "https:\/\/api.lufthansa.com\/v1\/references\/airports\/?limit=2&LHoperated=0&offset=1260",
                "@Rel": "last"
            }, {
                "@Href": "https:\/\/api.lufthansa.com\/v1\/references\/cities\/{cityCode}",
                "@Rel": "related"
            }, {
                "@Href": "https:\/\/api.lufthansa.com\/v1\/references\/countries\/{countryCode}",
                "@Rel": "related"
            }],
            "TotalCount": 1261
        }
    }
}`

So "Airport" is already an array which contains two objects with information about "AAL" and "AAR".

Would it be clearer and simpler to return array with one element in first case?

Thanks!




